### PR TITLE
Add aggregate function to expr package

### DIFF
--- a/expr/functions/aggregate/function.go
+++ b/expr/functions/aggregate/function.go
@@ -1,0 +1,372 @@
+package aggregate
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/bookingcom/carbonapi/expr/helper"
+	"github.com/bookingcom/carbonapi/expr/interfaces"
+	"github.com/bookingcom/carbonapi/expr/types"
+	"github.com/bookingcom/carbonapi/pkg/parser"
+	"github.com/go-graphite/carbonapi/expr/consolidations"
+)
+
+type aggregate struct {
+	interfaces.FunctionBase
+}
+
+func GetOrder() interfaces.Order {
+	return interfaces.Any
+}
+
+func New(configFile string) []interfaces.FunctionMetadata {
+	f := &aggregate{}
+	res := make([]interfaces.FunctionMetadata, 0)
+	for _, n := range []string{"aggregate"} {
+		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
+	}
+
+	// Also register aliases for each and every summarizer
+	for _, n := range consolidations.AvailableSummarizers {
+		res = append(res,
+			interfaces.FunctionMetadata{Name: n, F: f},
+			interfaces.FunctionMetadata{Name: n + "Series", F: f},
+		)
+	}
+	return res
+}
+
+// aggregate(*seriesLists)
+func (f *aggregate) Do(ctx context.Context, e parser.Expr, from, until int32, values map[parser.MetricRequest][]*types.MetricData, getTargetData interfaces.GetTargetData) ([]*types.MetricData, error) {
+	var args []*types.MetricData
+	isAggregateFunc := true
+
+	callback, err := e.GetStringArg(1)
+	if err != nil {
+		if e.Target() == "aggregate" {
+			return nil, err
+		} else {
+			args, err = helper.GetSeriesArgsAndRemoveNonExisting(ctx, e, from, until, values, getTargetData)
+			if err != nil {
+				return nil, err
+			}
+			callback = strings.Replace(e.Target(), "Series", "", 1)
+			isAggregateFunc = false
+		}
+	} else {
+		args, err = helper.GetSeriesArg(ctx, e.Args()[0], from, until, values, getTargetData)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// TODO: Implement xFilesFactor
+
+	//xFilesFactor, err := e.GetFloatArgDefault(2, 0)
+	//if err != nil {
+	//	return nil, err
+	//}
+
+	fmt.Println("args: ", args)
+	fmt.Println("args[0] values: ", args[0].Values)
+
+	aggFunc, ok := consolidations.ConsolidationToFunc[callback]
+	if !ok {
+		return nil, fmt.Errorf("unsupported consolidation function %s", callback)
+	}
+	target := fmt.Sprintf("%sSeries", callback)
+
+	e.SetTarget(target)
+	if isAggregateFunc {
+		e.SetRawArgs(e.Args()[0].Target())
+	}
+	name := fmt.Sprintf("%s(%s)", e.Target(), e.RawArgs())
+
+	aggregated, err := helper.AggregateSeries(name, args, aggFunc)
+	if err != nil {
+		return aggregated, err
+	}
+	fmt.Println("Aggregated: ", aggregated)
+	//for i := 0; i < len(args[0].Values); i++ {
+	//	if !helper.XffValues(args, i, xFilesFactor) {
+	//		args[0]
+	//	}
+	//}
+
+	return aggregated, nil
+}
+
+// Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web
+func (f *aggregate) Description() map[string]types.FunctionDescription {
+	// TODO(Civil): this should be reworked. Graphite do not provide consistent mappings for some of the consolidation
+	// functions. Also it's very easy to miss something obvious here.
+	return map[string]types.FunctionDescription{
+		"aggregate": {
+			Name:        "aggregate",
+			Function:    "aggregate(seriesList, func, xFilesFactor=None)",
+			Description: "Aggregate series using the specified function.\n\nExample:\n\n.. code-block:: none\n\n  &target=aggregate(host.cpu-[0-7}.cpu-{user,system}.value, \"sum\")\n\nThis would be the equivalent of\n\n.. code-block:: none\n\n  &target=sumSeries(host.cpu-[0-7}.cpu-{user,system}.value)\n\nThis function can be used with aggregation functions ``average``, ``median``, ``sum``, ``min``,\n``max``, ``diff``, ``stddev``, ``count``, ``range``, ``multiply`` & ``last``.",
+			Module:      "graphite.render.functions",
+			Group:       "Combine",
+			Params: []types.FunctionParam{
+				{
+					Name:     "seriesList",
+					Type:     types.SeriesList,
+					Required: true,
+				},
+				{
+					Name:     "func",
+					Type:     types.AggFunc,
+					Required: true,
+					Options:  types.StringsToSuggestionList(consolidations.AvailableConsolidationFuncs()),
+				},
+				/*
+					{
+						Name: "xFilesFactor",
+						Type: types.Float,
+					},
+				*/
+			},
+		},
+		"averageSeries": {
+			Description: "Short Alias: avg()\n\nTakes one metric or a wildcard seriesList.\nDraws the average value of all metrics passed at each time.\n\nExample:\n\n.. code-block:: none\n\n  &target=averageSeries(company.server.*.threads.busy)\n\nThis is an alias for :py:func:`aggregate <aggregate>` with aggregation ``average``.",
+			Function:    "averageSeries(*seriesLists)",
+			Group:       "Combine",
+			Module:      "graphite.render.functions",
+			Name:        "averageSeries",
+			Params: []types.FunctionParam{
+				{
+					Multiple: true,
+					Name:     "seriesLists",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+			},
+		},
+		"avg": {
+			Description: "Short Alias: avg()\n\nTakes one metric or a wildcard seriesList.\nDraws the average value of all metrics passed at each time.\n\nExample:\n\n.. code-block:: none\n\n  &target=averageSeries(company.server.*.threads.busy)\n\nThis is an alias for :py:func:`aggregate <aggregate>` with aggregation ``average``.",
+			Function:    "avg(*seriesLists)",
+			Group:       "Combine",
+			Module:      "graphite.render.functions",
+			Name:        "avg",
+			Params: []types.FunctionParam{
+				{
+					Multiple: true,
+					Name:     "seriesLists",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+			},
+		},
+		"max": {
+			Description: "Takes one metric or a wildcard seriesList.\nFor each datapoint from each metric passed in, pick the maximum value and graph it.\n\nExample:\n\n.. code-block:: none\n\n  &target=maxSeries(Server*.connections.total)\n\nThis is an alias for :py:func:`aggregate <aggregate>` with aggregation ``max``.",
+			Function:    "maxSeries(*seriesLists)",
+			Group:       "Combine",
+			Module:      "graphite.render.functions",
+			Name:        "maxSeries",
+			Params: []types.FunctionParam{
+				{
+					Multiple: true,
+					Name:     "seriesLists",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+			},
+		},
+		"maxSeries": {
+			Description: "Takes one metric or a wildcard seriesList.\nFor each datapoint from each metric passed in, pick the maximum value and graph it.\n\nExample:\n\n.. code-block:: none\n\n  &target=maxSeries(Server*.connections.total)\n\nThis is an alias for :py:func:`aggregate <aggregate>` with aggregation ``max``.",
+			Function:    "maxSeries(*seriesLists)",
+			Group:       "Combine",
+			Module:      "graphite.render.functions",
+			Name:        "maxSeries",
+			Params: []types.FunctionParam{
+				{
+					Multiple: true,
+					Name:     "seriesLists",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+			},
+		},
+		"min": {
+			Description: "Takes one metric or a wildcard seriesList.\nFor each datapoint from each metric passed in, pick the minimum value and graph it.\n\nExample:\n\n.. code-block:: none\n\n  &target=minSeries(Server*.connections.total)\n\nThis is an alias for :py:func:`aggregate <aggregate>` with aggregation ``min``.",
+			Function:    "minSeries(*seriesLists)",
+			Group:       "Combine",
+			Module:      "graphite.render.functions",
+			Name:        "minSeries",
+			Params: []types.FunctionParam{
+				{
+					Multiple: true,
+					Name:     "seriesLists",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+			},
+		},
+		"minSeries": {
+			Description: "Takes one metric or a wildcard seriesList.\nFor each datapoint from each metric passed in, pick the minimum value and graph it.\n\nExample:\n\n.. code-block:: none\n\n  &target=minSeries(Server*.connections.total)\n\nThis is an alias for :py:func:`aggregate <aggregate>` with aggregation ``min``.",
+			Function:    "minSeries(*seriesLists)",
+			Group:       "Combine",
+			Module:      "graphite.render.functions",
+			Name:        "minSeries",
+			Params: []types.FunctionParam{
+				{
+					Multiple: true,
+					Name:     "seriesLists",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+			},
+		},
+		"sum": {
+			Description: "Short form: sum()\n\nThis will add metrics together and return the sum at each datapoint. (See\nintegral for a sum over time)\n\nExample:\n\n.. code-block:: none\n\n  &target=sum(company.server.application*.requestsHandled)\n\nThis would show the sum of all requests handled per minute (provided\nrequestsHandled are collected once a minute).   If metrics with different\nretention rates are combined, the coarsest metric is graphed, and the sum\nof the other metrics is averaged for the metrics with finer retention rates.\n\nThis is an alias for :py:func:`aggregate <aggregate>` with aggregation ``sum``.",
+			Function:    "sum(*seriesLists)",
+			Group:       "Combine",
+			Module:      "graphite.render.functions",
+			Name:        "sum",
+			Params: []types.FunctionParam{
+				{
+					Multiple: true,
+					Name:     "seriesLists",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+			},
+		},
+		"sumSeries": {
+			Description: "Short form: sum()\n\nThis will add metrics together and return the sum at each datapoint. (See\nintegral for a sum over time)\n\nExample:\n\n.. code-block:: none\n\n  &target=sum(company.server.application*.requestsHandled)\n\nThis would show the sum of all requests handled per minute (provided\nrequestsHandled are collected once a minute).   If metrics with different\nretention rates are combined, the coarsest metric is graphed, and the sum\nof the other metrics is averaged for the metrics with finer retention rates.\n\nThis is an alias for :py:func:`aggregate <aggregate>` with aggregation ``sum``.",
+			Function:    "sumSeries(*seriesLists)",
+			Group:       "Combine",
+			Module:      "graphite.render.functions",
+			Name:        "sumSeries",
+			Params: []types.FunctionParam{
+				{
+					Multiple: true,
+					Name:     "seriesLists",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+			},
+		},
+		"stddev": {
+			Description: "Short form: stddev()\n\nTakes one metric or a wildcard seriesList.\nDraws the standard deviation of all metrics passed at each time.\n\nExample:\n\n.. code-block:: none\n\n  &target=stddevSeries(company.server.*.threads.busy)\n\nThis is an alias for :py:func:`aggregate <aggregate>` with aggregation ``stddev``.",
+			Function:    "stddev(*seriesLists)",
+			Group:       "Combine",
+			Module:      "graphite.render.functions",
+			Name:        "stddev",
+			Params: []types.FunctionParam{
+				{
+					Multiple: true,
+					Name:     "seriesLists",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+			},
+		},
+		"stddevSeries": {
+			Description: "Short form: stddev()\n\nTakes one metric or a wildcard seriesList.\nDraws the standard deviation of all metrics passed at each time.\n\nExample:\n\n.. code-block:: none\n\n  &target=stddevSeries(company.server.*.threads.busy)\n\nThis is an alias for :py:func:`aggregate <aggregate>` with aggregation ``stddev``.",
+			Function:    "stddevSeries(*seriesLists)",
+			Group:       "Combine",
+			Module:      "graphite.render.functions",
+			Name:        "stddevSeries",
+			Params: []types.FunctionParam{
+				{
+					Multiple: true,
+					Name:     "seriesLists",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+			},
+		},
+		"count": {
+			Description: "Draws a horizontal line representing the number of nodes found in the seriesList.\n\n.. code-block:: none\n\n  &target=count(carbon.agents.*.*)",
+			Function:    "count(*seriesLists)",
+			Group:       "Combine",
+			Module:      "graphite.render.functions",
+			Name:        "count",
+			Params: []types.FunctionParam{
+				{
+					Multiple: true,
+					Name:     "seriesLists",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+			},
+		},
+		"countSeries": {
+			Description: "Draws a horizontal line representing the number of nodes found in the seriesList.\n\n.. code-block:: none\n\n  &target=countSeries(carbon.agents.*.*)",
+			Function:    "countSeries(*seriesLists)",
+			Group:       "Combine",
+			Module:      "graphite.render.functions",
+			Name:        "countSeries",
+			Params: []types.FunctionParam{
+				{
+					Multiple: true,
+					Name:     "seriesLists",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+			},
+		},
+		"diff": {
+			Description: "Subtracts series 2 through n from series 1.\n\nExample:\n\n.. code-block:: none\n\n  &target=diff(service.connections.total,service.connections.failed)\n\nTo diff a series and a constant, one should use offset instead of (or in\naddition to) diffSeries\n\nExample:\n\n.. code-block:: none\n\n  &target=offset(service.connections.total,-5)\n\n  &target=offset(diffSeries(service.connections.total,service.connections.failed),-4)\n\nThis is an alias for :py:func:`aggregate <aggregate>` with aggregation ``diff``.",
+			Function:    "diff(*seriesLists)",
+			Group:       "Combine",
+			Module:      "graphite.render.functions",
+			Name:        "diff",
+			Params: []types.FunctionParam{
+				{
+					Multiple: true,
+					Name:     "seriesLists",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+			},
+		},
+		"diffSeries": {
+			Description: "Subtracts series 2 through n from series 1.\n\nExample:\n\n.. code-block:: none\n\n  &target=diffSeries(service.connections.total,service.connections.failed)\n\nTo diff a series and a constant, one should use offset instead of (or in\naddition to) diffSeries\n\nExample:\n\n.. code-block:: none\n\n  &target=offset(service.connections.total,-5)\n\n  &target=offset(diffSeries(service.connections.total,service.connections.failed),-4)\n\nThis is an alias for :py:func:`aggregate <aggregate>` with aggregation ``diff``.",
+			Function:    "diffSeries(*seriesLists)",
+			Group:       "Combine",
+			Module:      "graphite.render.functions",
+			Name:        "diffSeries",
+			Params: []types.FunctionParam{
+				{
+					Multiple: true,
+					Name:     "seriesLists",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+			},
+		},
+		"multiply": {
+			Description: "Takes two or more series and multiplies their points. A constant may not be\nused. To multiply by a constant, use the scale() function.\n\nExample:\n\n.. code-block:: none\n\n  &target=multiplySeries(Series.dividends,Series.divisors)\n\nThis is an alias for :py:func:`aggregate <aggregate>` with aggregation ``multiply``.",
+			Function:    "multiply(*seriesLists)",
+			Group:       "Combine",
+			Module:      "graphite.render.functions",
+			Name:        "multiply",
+			Params: []types.FunctionParam{
+				{
+					Multiple: true,
+					Name:     "seriesLists",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+			},
+		},
+		"multiplySeries": {
+			Description: "Takes two or more series and multiplies their points. A constant may not be\nused. To multiply by a constant, use the scale() function.\n\nExample:\n\n.. code-block:: none\n\n  &target=multiplySeries(Series.dividends,Series.divisors)\n\nThis is an alias for :py:func:`aggregate <aggregate>` with aggregation ``multiply``.",
+			Function:    "multiplySeries(*seriesLists)",
+			Group:       "Combine",
+			Module:      "graphite.render.functions",
+			Name:        "multiplySeries",
+			Params: []types.FunctionParam{
+				{
+					Multiple: true,
+					Name:     "seriesLists",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+			},
+		},
+	}
+}

--- a/expr/functions/aggregate/function_test.go
+++ b/expr/functions/aggregate/function_test.go
@@ -1,0 +1,279 @@
+package aggregate
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/metadata"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+	th "github.com/go-graphite/carbonapi/tests"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestAverageSeries(t *testing.T) {
+	now32 := int64(time.Now().Unix())
+
+	tests := []th.EvalTestItem{
+		{
+			`aggregate(metric[123], "avg")`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric[123]", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32),
+					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
+					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("avgSeries(metric[123])",
+				[]float64{2, math.NaN(), 3, 4, 5, 5.5}, 1, now32)},
+		},
+		{
+			`aggregate(metric[123], "avg_zero")`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric[123]", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 4, 4, 6}, 1, now32),
+					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
+					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("avg_zeroSeries(metric[123])",
+				[]float64{2, math.NaN(), 3, 3, 5, 4}, 1, now32)},
+		},
+		{
+			`aggregate(metric[123], "count")`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric[123]", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32),
+					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
+					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("countSeries(metric[123])",
+				[]float64{3, math.NaN(), 3, 2, 3, 2}, 1, now32)},
+		},
+		{
+			`aggregate(metric[123], "diff")`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric[123]", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32),
+					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
+					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("diffSeries(metric[123])",
+				[]float64{-4, math.NaN(), -5, -2, -7, -1}, 1, now32)},
+		},
+		{
+			`aggregate(metric[123], "last")`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric[123]", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32),
+					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
+					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("lastSeries(metric[123])",
+				[]float64{3, math.NaN(), 4, 5, 6, 6}, 1, now32)},
+		},
+		{
+			`aggregate(metric[123], "max")`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric[123]", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32),
+					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
+					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("maxSeries(metric[123])",
+				[]float64{3, math.NaN(), 4, 5, 6, 6}, 1, now32)},
+		},
+		{
+			`aggregate(metric[123], "min")`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric[123]", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 6}, 1, now32),
+					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 5}, 1, now32),
+					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("minSeries(metric[123])",
+				[]float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32)},
+		},
+		{
+			`aggregate(metric[123], "median")`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric[123]", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 6}, 1, now32),
+					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 5}, 1, now32),
+					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("medianSeries(metric[123])",
+				[]float64{2, math.NaN(), 3, 4, 5, 5.5}, 1, now32)},
+		},
+		{
+			`aggregate(metric[123], "multiply")`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric[123]", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 6}, 1, now32),
+					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 5}, 1, now32),
+					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("multiplySeries(metric[123])",
+				[]float64{6, math.NaN(), 24, 15, 120, 30}, 1, now32)},
+		},
+		{
+			`aggregate(metric[123], "range")`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric[123]", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 6}, 1, now32),
+					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 5}, 1, now32),
+					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("rangeSeries(metric[123])",
+				[]float64{2, math.NaN(), 2, 2, 2, 1}, 1, now32)},
+		},
+		{
+			`aggregate(metric[123], "sum")`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric[123]", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 6}, 1, now32),
+					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 5}, 1, now32),
+					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("sumSeries(metric[123])",
+				[]float64{6, math.NaN(), 9, 8, 15, 11}, 1, now32)},
+		},
+		{
+			`stddevSeries(metric[123])`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric[123]", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 6}, 1, now32),
+					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 5}, 1, now32),
+					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("stddevSeries(metric[123])",
+				[]float64{0.816496580927726, math.NaN(), 0.816496580927726, 1, 0.816496580927726, 0.5}, 1, now32)},
+		},
+		{
+			`stddevSeries(metric1,metric2,metric3)`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{2, 4, 6, 8, 10}, 1, now32)},
+				{"metric3", 0, 1}: {types.MakeMetricData("metric3", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("stddevSeries(metric1,metric2,metric3)",
+				[]float64{0.4714045207910317, 0.9428090415820634, 1.4142135623730951, 1.8856180831641267, 2.357022603955158}, 1, now32)},
+		},
+		{
+			`aggregate(metric[123], "stddev")`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric[123]", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 6}, 1, now32),
+					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 5}, 1, now32),
+					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("stddevSeries(metric[123])",
+				[]float64{0.816496580927726, math.NaN(), 0.816496580927726, 1, 0.816496580927726, 0.5}, 1, now32)},
+		},
+		{
+			`aggregate(metric[123], "stddev")`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric[123]", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32),
+					types.MakeMetricData("metric2", []float64{2, 4, 6, 8, 10}, 1, now32),
+					types.MakeMetricData("metric3", []float64{1, 2, 3, 4, 5}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("stddevSeries(metric[123])",
+				[]float64{0.4714045207910317, 0.9428090415820634, 1.4142135623730951, 1.8856180831641267, 2.357022603955158}, 1, now32)},
+		},
+
+		// sum
+		{
+			`sum(metric1,metric2)`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{0, -1, 2, -3, 4, 5}, 1, now32)},
+				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{0, 1, -2, 3, -4, -5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("sumSeries(metric1,metric2)",
+				[]float64{0, 0, 0, 0, 0, 0}, 1, now32)},
+		},
+		{
+			"sum(metric1,metric2,metric3)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5, math.NaN()}, 1, now32)},
+				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{2, 3, math.NaN(), 5, 6, math.NaN()}, 1, now32)},
+				{"metric3", 0, 1}: {types.MakeMetricData("metric3", []float64{3, 4, 5, 6, math.NaN(), math.NaN()}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("sumSeries(metric1,metric2,metric3)", []float64{6, 9, 8, 15, 11, math.NaN()}, 1, now32)},
+		},
+		{
+			"sum(metric1,metric2,metric3,metric4)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5, math.NaN()}, 1, now32)},
+				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{2, 3, math.NaN(), 5, 6, math.NaN()}, 1, now32)},
+				{"metric3", 0, 1}: {types.MakeMetricData("metric3", []float64{3, 4, 5, 6, math.NaN(), math.NaN()}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("sumSeries(metric1,metric2,metric3)", []float64{6, 9, 8, 15, 11, math.NaN()}, 1, now32)},
+		},
+
+		// minMax
+		{
+			"maxSeries(metric1,metric2,metric3)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32)},
+				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32)},
+				{"metric3", 0, 1}: {types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("maxSeries(metric1,metric2,metric3)",
+				[]float64{3, math.NaN(), 4, 5, 6, 6}, 1, now32)},
+		},
+		{
+			"minSeries(metric1,metric2,metric3)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32)},
+				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32)},
+				{"metric3", 0, 1}: {types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("minSeries(metric1,metric2,metric3)",
+				[]float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32)},
+		},
+
+		// avg
+		{
+			"averageSeries(metric1,metric2,metric3)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32)},
+				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32)},
+				{"metric3", 0, 1}: {types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("averageSeries(metric1,metric2,metric3)",
+				[]float64{2, math.NaN(), 3, 4, 5, 5.5}, 1, now32)},
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExpr(t, &tt)
+		})
+	}
+
+}

--- a/expr/types/list.go
+++ b/expr/types/list.go
@@ -212,6 +212,20 @@ func (t *Suggestion) UnmarshalJSON(d []byte) error {
 	return nil
 }
 
+type Option struct {
+	Type  SuggestionTypes
+	Value interface{}
+}
+
+func StringsToSuggestionList(in []string) []Suggestion {
+	res := make([]Suggestion, 0, len(in))
+
+	for _, v := range in {
+		res = append(res, Suggestion{Type: SString, Value: v})
+	}
+	return res
+}
+
 // FunctionParam contains list of all available parameters of function
 type FunctionParam struct {
 	Name        string        `json:"name"`


### PR DESCRIPTION
## What issue is this change attempting to solve?
This PR adds support for the Graphite aggregate method into Carbon API. This code was mostly taken from the go-graphite/carbonapi implementation of aggregate, with some refactoring.

## How does this change solve the problem? Why is this the best approach?

## How can we be sure this works as expected?
Tests were added as part of this change.
